### PR TITLE
Purpeille Integration: "Greater Potential" warpath

### DIFF
--- a/src/main/resources/assets/doublejumpattribute/lang/en_us.json
+++ b/src/main/resources/assets/doublejumpattribute/lang/en_us.json
@@ -1,5 +1,8 @@
 {
   "item.doublejumpattribute.jump_boots" : "Jump Boots",
   "attribute.doublejumpattribute.jumps" : "Extra Jumps",
-  "subtitles.doublejumpattribute.jump" : "Double Jump"
+  "subtitles.doublejumpattribute.jump" : "Double Jump",
+  "aspect.doublejumpattribute.greater": "Greater",
+  "revelation.doublejumpattribute.potential": "Potential",
+  "rite.doublejumpattribute.potential": "Reach for the stars."
 }

--- a/src/main/resources/data/doublejumpattribute/warpath/aspects/greater.json
+++ b/src/main/resources/data/doublejumpattribute/warpath/aspects/greater.json
@@ -1,0 +1,12 @@
+{
+  "tone": "release",
+  "color": 8271574,
+  "catalyst": {
+    "item": "minecraft:firework_rocket"
+  },
+  "modifier": 1.3,
+  "ignore_slot": true,
+  "whitelist": [
+    "doublejumpattribute:potential"
+  ]
+}

--- a/src/main/resources/data/doublejumpattribute/warpath/revelations/potential.json
+++ b/src/main/resources/data/doublejumpattribute/warpath/revelations/potential.json
@@ -1,0 +1,21 @@
+{
+  "tone": "release",
+  "color": 8271574,
+  "catalyst": {
+    "item": "minecraft:rabbit_foot"
+  },
+  "modifier": 1.3,
+  "ignore_slot": true,
+  "whitelist": [
+    "doublejumpattribute:greater"
+  ],
+  "attribute": "doublejumpattribute:double_jump_attribute",
+  "affinity": {
+    "item": "purpeille:purpeille_boots"
+  },
+  "synergy": {
+    "doublejumpattribute:greater": "identical"
+  },
+  "multiply": false,
+  "force_int": true
+}

--- a/src/main/resources/data/purpeille/tags/items/aspect_catalyst.json
+++ b/src/main/resources/data/purpeille/tags/items/aspect_catalyst.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:firework_rocket"
+  ]
+}

--- a/src/main/resources/data/purpeille/tags/items/revelation_catalyst.json
+++ b/src/main/resources/data/purpeille/tags/items/revelation_catalyst.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:rabbit_foot"
+  ]
+}


### PR DESCRIPTION
This warpath uses an Indigo color. The revelation makes use of the new `force_int` feature to never produce a decimal modifier value (to reduce confusion). On its own, it yields `1`, but with the "Greater" aspect, it yields `2`. Combined with the affinity of Purpeille Boots, it produces `3`.

These additions are non-intrusive and only activate when Purpeille is installed. 